### PR TITLE
chore: plugin images

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
 
       - name: Test
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kitsu'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kitsu'
+    
     steps:
       - name: Get version from GITHUB_REF
         id: get-version

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-kitsu'
+    
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.15.0

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 ## About
 This plugin adds the metadata provider for [Kitsu](https://kitsu.io).
 
+## Installation
+
+[See the official documentation for install instructions](https://jellyfin.org/docs/general/server/plugins/index.html#installing).
+
 ## Build
 
 1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 <h3 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h3>
 
 <p align="center">
-<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<img alt="Plugin Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/plugins/SVG/jellyfin-plugin-kitsu.svg?sanitize=true"/>
 <br/>
 <br/>
 <a href="https://github.com/jellyfin/jellyfin-plugin-kitsu/actions?query=workflow%3A%22Test+Build+Plugin%22">
 <img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/jellyfin/jellyfin-plugin-kitsu/Test%20Build%20Plugin.svg">
 </a>
 <a href="https://github.com/jellyfin/jellyfin-plugin-kitsu">
-<img alt="MIT License" src="https://img.shields.io/github/license/jellyfin/jellyfin-plugin-kitsu.svg"/>
+<img alt="GPLv2 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-plugin-kitsu.svg"/>
 </a>
 <a href="https://github.com/jellyfin/jellyfin-plugin-kitsu/releases">
 <img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-plugin-kitsu.svg"/>
@@ -17,4 +17,29 @@
 </p>
 
 ## About
-This plugin adds the metadata provider for [Kitsu](https://kitsu.io)
+This plugin adds the metadata provider for [Kitsu](https://kitsu.io).
+
+## Build
+
+1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
+
+2. Build plugin with following command
+  ```
+  dotnet publish --configuration Release --output bin
+  ```
+
+3. Place the dll-file in the `plugins/kitsu` folder (you might need to create the folders) of your JF install
+
+## Releasing
+
+To release the plugin we recommend [JPRM](https://github.com/oddstr13/jellyfin-plugin-repository-manager) that will build and package the plugin.
+For additional context and for how to add the packaged plugin zip to a plugin manifest see the [JPRM documentation](https://github.com/oddstr13/jellyfin-plugin-repository-manager) for more info.
+
+## Contributing
+
+We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
+In general refer to our [contributing guidelines](https://github.com/jellyfin/.github/blob/master/CONTRIBUTING.md) for further information.
+
+## Licence
+
+This plugins code and packages are distributed under the GPLv2 License. See [LICENSE](./LICENSE) for more information.

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Kitsu"
 guid: "88d809e2-056b-47f4-9911-073949b9963f"
+imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kitsu.png"
 version: "2.0.0.0"
 targetAbi: "10.7.0.0"
 framework: "net5.0"
@@ -10,8 +11,8 @@ description: >
 category: "Metadata"
 owner: "jellyfin"
 artifacts:
-- "Jellyfin.Plugin.Kitsu.dll"
-changelog: >
+  - "Jellyfin.Plugin.Kitsu.dll"
+changelog: |
   - Split out from the Anime plugin
   - Remove dependency on DependencyInjection
 


### PR DESCRIPTION
* applies some smaller improvements to workflows
* updates readme with plugin-image
* adds plugin `imageUrl` to build.yaml

Merge Checklist:

* [x] either manually or via CI add plugin-images to [repo.jellyfin.org](https://repo.jellyfin.org/releases/plugin/)
* [x] ensure the plugin png is present within the plugin directory with the correct name on `repo.jellyfin.org`