### PR TITLE
Round community rating to single decimal place

### DIFF
--- a/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
+++ b/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
@@ -78,7 +78,7 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO.Metadata
                     // KitsuIO has a max rating of 100
                     CommunityRating = string.IsNullOrWhiteSpace(seriesInfo.Data.Attributes.AverageRating)
                         ? null
-                        : (float?) float.Parse(seriesInfo.Data.Attributes.AverageRating, System.Globalization.CultureInfo.InvariantCulture) / 10,
+                        : MathF.Round(float.Parse(seriesInfo.Data.Attributes.AverageRating, System.Globalization.CultureInfo.InvariantCulture) / 10, 1),
                     ProviderIds = new Dictionary<string, string>() {{"Kitsu", kitsuId}},
                     Genres = seriesInfo.Included?.Select(x => x.Attributes.Name).ToArray()
                              ?? Array.Empty<string>()


### PR DESCRIPTION
### Description

Jellyfin web has a validation on the "Community rating" field to only allow a single decimal place, in the current plugin implementation this limitation does not exist and the metadata provider will return a value that is not valid.

### Change

* Round the community rating value to a single decimal

### Issues

* Fixes: https://github.com/jellyfin/jellyfin-plugin-kitsu/issues/16