### PR TITLE
Update kitsu domain

### DIFF
--- a/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/ApiClient/KitsuIoApi.cs
+++ b/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/ApiClient/KitsuIoApi.cs
@@ -12,7 +12,7 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO.ApiClient
 {
     internal class KitsuIoApi
     {
-        private const string _apiBaseUrl = "https://kitsu.io/api/edge";
+        private const string _apiBaseUrl = "https://kitsu.app/api/edge";
         private static readonly JsonSerializerOptions _serializerOptions;
 
         static KitsuIoApi()

--- a/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/KitsuIoExternalId.cs
+++ b/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/KitsuIoExternalId.cs
@@ -21,6 +21,6 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO
             => ExternalIdMediaType.Series;
 
         public string UrlFormatString
-            => "https://kitsu.io/anime/{0}";
+            => "https://kitsu.app/anime/{0}";
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 ## About
-This plugin adds the metadata provider for [Kitsu](https://kitsu.io).
+This plugin adds the metadata provider for [Kitsu](https://kitsu.app).
 
 ## Installation
 


### PR DESCRIPTION
### Description

Kitsu has migrated to a new domain (kitsu.app). While the old domain currently redirects to the new one and the API continues to function correctly, updating to the new domain ensures future compatibility.

### Changes

* Updated all references to the Kitsu site to use the new domain (kitsu.app).

### Issues

* Fixes: https://github.com/jellyfin/jellyfin-plugin-kitsu/issues/30
