### PR TITLE
Add missing dates to metadata

### DIFF
--- a/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/ApiClient/Models/KitsuSeriesAttributes.cs
+++ b/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/ApiClient/Models/KitsuSeriesAttributes.cs
@@ -8,6 +8,7 @@ namespace Jellyfin.Plugin.Kitsu.Providers.KitsuIO.ApiClient.Models
         public KitsuTitles Titles { get; set; }
         public string AverageRating { get; set; }
         public DateTimeOffset? StartDate { get; set; }
+        public DateTimeOffset? EndDate { get; set; }
         public KitsuImage PosterImage { get; set; }
         public KitsuImage CoverImage { get; set; }
     }

--- a/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
+++ b/Jellyfin.Plugin.Kitsu/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
@@ -86,7 +86,10 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO.Metadata
                         : MathF.Round(float.Parse(seriesInfo.Data.Attributes.AverageRating, System.Globalization.CultureInfo.InvariantCulture) / 10, 1),
                     ProviderIds = new Dictionary<string, string>() {{"Kitsu", kitsuId}},
                     Genres = seriesInfo.Included?.Select(x => x.Attributes.Name).ToArray()
-                             ?? Array.Empty<string>()
+                             ?? Array.Empty<string>(),
+                    ProductionYear = seriesInfo.Data.Attributes.StartDate?.Year,
+                    PremiereDate = seriesInfo.Data.Attributes.StartDate?.DateTime,
+                    EndDate = seriesInfo.Data.Attributes.EndDate?.DateTime
                 };
 
                 StoreImageUrl(kitsuId, seriesInfo.Data.Attributes.PosterImage.Original.ToString(), "image");
@@ -127,7 +130,7 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO.Metadata
                 ImageUrl = series.Attributes.PosterImage.Medium.ToString(),
                 Overview = series.Attributes.Synopsis,
                 ProductionYear = series.Attributes.StartDate?.Year,
-                PremiereDate = series.Attributes.StartDate?.DateTime,
+                PremiereDate = series.Attributes.StartDate?.DateTime
             };
             parsedSeries.SetProviderId("Kitsu", series.Id.ToString());
 


### PR DESCRIPTION
Adding production year along with premiere and end dates to series metadata, as currently they aren't passed at all.