### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/Jellyfin.Plugin.Kitsu/Jellyfin.Plugin.Kitsu.csproj
+++ b/Jellyfin.Plugin.Kitsu/Jellyfin.Plugin.Kitsu.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Kitsu</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Kitsu/Jellyfin.Plugin.Kitsu.csproj
+++ b/Jellyfin.Plugin.Kitsu/Jellyfin.Plugin.Kitsu.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="12.*-*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Kitsu"
 guid: "88d809e2-056b-47f4-9911-073949b9963f"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kitsu.png"
 version: 7
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 overview: "Kitsu metadata provider"
 description: >

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ guid: "88d809e2-056b-47f4-9911-073949b9963f"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kitsu.png"
 version: 7
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 overview: "Kitsu metadata provider"
 description: >
   Kitsu metadata provider

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Kitsu"
 guid: "88d809e2-056b-47f4-9911-073949b9963f"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-kitsu.png"
 version: 7
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 overview: "Kitsu metadata provider"
 description: >


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.